### PR TITLE
Added bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "moar-elements",
+  "version": "1.0.0",
+  "homepage": "https://github.com/CITguy/moar-elements",
+  "authors": [
+    "Dmitry Fadeyev <dmitry@fadeyev.net>",
+    "Ryan Johnson <rhino.citguy@gmail.com>"
+  ],
+  "description": "A set of basic mixins for the LESS CSS pre-processor",
+  "main": "elements.less",
+  "keywords": [
+    "less",
+    "elements",
+    "mixins",
+    "basic"
+  ],
+  "license": "WTFPL"
+}


### PR DESCRIPTION
I'd like to have moar-elements in the bower repository so that I don't have to put external dependencies into my projects. I therefore created a bower.json file to make it easy to push it to the registry. Because it is recommended that you put a license into the bower.json, I figured that the WTFPL (What The Fuck Public License) would suit best of the available licenses.
